### PR TITLE
add missing context for /vendor/bin/resku_rescue_kicker

### DIFF
--- a/whitechapel/vendor/google/file_contexts
+++ b/whitechapel/vendor/google/file_contexts
@@ -330,6 +330,7 @@
 
 
 # Trusty
+/vendor/bin/resku_rescue_kicker      u:object_r:tee_exec:s0
 /vendor/bin/storageproxyd            u:object_r:tee_exec:s0
 /vendor/bin/trusty_apploader         u:object_r:trusty_apploader_exec:s0
 /vendor/bin/hw/android\.hardware\.gatekeeper@1\.0-service\.trusty                u:object_r:hal_gatekeeper_default_exec:s0


### PR DESCRIPTION
init log before the change:

```
root     1     1 I init    : processing action (ro.vendor.trusty.storage.fs_ready=1) from (/vendor/etc/init/init.resku_rescue.rc:2)
root     1     1 I init    : Command 'exec_background - system shell -- /vendor/bin/resku_rescue_kicker -d /dev/trusty-ipc-dev0' action=ro.vendor.trusty.storage.fs_ready=1 (/vendor/etc/init/init.resku_rescue.rc:3) took 0ms and failed: Could not start exec background service: File /vendor/bin/resku_rescu
       │ e_kicker(labeled "u:object_r:vendor_file:s0") has incorrect label or no domain transition from u:r:init:s0 to another SELinux domain defined. Have you configured your service correctly? https://source.android.com/security/selinux/device-policy#label_new_services_and_address_denials. Note: this error shows up even in permis
       │ sive mode in order to make auditing denials possible.
```

init log after the change:
```
root     1     1 I init    : processing action (ro.vendor.trusty.storage.fs_ready=1) from (/vendor/etc/init/init.resku_rescue.rc:2)
root     1     1 I init    : starting service 'exec 21 (/vendor/bin/resku_rescue_kicker -d /dev/trusty-ipc-dev0)'...
1000  1050  1050 I resku_rescue_kicker: trusty dev: /dev/trusty-ipc-dev0
root     0     0 I trusty  : resku_rescue: 139: Resku Rescue completed without error.
root     1     1 I init    : Service 'exec 21 (/vendor/bin/resku_rescue_kicker -d /dev/trusty-ipc-dev0)' (pid 1050) exited with status 0 oneshot service took 0.061000 seconds in background
root     1     1 I init    : Sending signal 9 to service 'exec 21 (/vendor/bin/resku_rescue_kicker -d /dev/trusty-ipc-dev0)' (pid 1050) process group...
```
